### PR TITLE
Improve configuration handling

### DIFF
--- a/src/hades/common/check_db.py
+++ b/src/hades/common/check_db.py
@@ -7,8 +7,9 @@ import contextlib
 from sqlalchemy import func, select
 from sqlalchemy.exc import DBAPIError
 
+from hades.common.cli import ArgumentParser, parser as common_parser
 from . import db
-from hades.config.loader import get_config, CheckWrapper
+from hades.config.loader import load_config
 
 logger = logging.getLogger(__package__)
 
@@ -45,8 +46,10 @@ def check_table(conn, table):
     conn.execute(select([func.count()]).select_from(table)).scalar()
 
 
-def main(args):
-    config = CheckWrapper(get_config())
+def main():
+    parser = ArgumentParser(parents=[common_parser])
+    args = parser.parse_args()
+    config = load_config(args.config, runtime_checks=True)
     try:
         with user(config['HADES_AGENT_USER']) as user_name:
             check_database(user_name, db.metadata.tables.values())
@@ -63,4 +66,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv))
+    sys.exit(main())

--- a/src/hades/common/cli.py
+++ b/src/hades/common/cli.py
@@ -1,0 +1,16 @@
+import argparse
+import os
+import sys
+from gettext import gettext as _
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        args = {'prog': self.prog, 'message': message}
+        self.exit(os.EX_USAGE, _('%(prog)s: error: %(message)s\n') % args)
+
+
+parser = ArgumentParser(add_help=False)
+parser.add_argument('-c', '--config', type=argparse.FileType('rb'),
+                    default=None, help="Path to config file")

--- a/src/hades/common/db.py
+++ b/src/hades/common/db.py
@@ -7,13 +7,11 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import INET, MACADDR
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import expression
-from hades.config.loader import CheckWrapper, get_config
+from hades.config.loader import get_config
 
 
 logger = logging.getLogger(__name__)
-config = CheckWrapper(get_config())
-engine = create_engine(config.SQLALCHEMY_DATABASE_URI)
-metadata = MetaData(bind=engine)
+metadata = MetaData()
 
 dhcphost = Table(
     'dhcphost', metadata,
@@ -145,6 +143,8 @@ def pg_utcnow(element, compiler, **kw):
 
 
 def get_connection():
+    config = get_config(True)
+    engine = create_engine(config.SQLALCHEMY_DATABASE_URI)
     return engine.connect()
 
 
@@ -192,6 +192,7 @@ def get_latest_auth_attempt(mac):
     :rtype: [([str], datetime)]|None
     """
     connection = get_connection()
+    config = get_config(True)
     interval = config.HADES_REAUTHENTICATION_INTERVAL
     result = connection.execute(
         select([radpostauth.c.replymessage, radpostauth.c.authdate])

--- a/src/hades/common/util.py
+++ b/src/hades/common/util.py
@@ -1,19 +1,6 @@
 import collections
-import functools
-from functools import reduce
 import operator
-
-
-def memoize(f):
-    f._cache = None
-
-    @functools.wraps(f)
-    def wrapper():
-        if f._cache is None:
-            f._cache = f()
-        return f._cache
-
-    return wrapper
+from functools import reduce
 
 
 class frozendict(collections.Mapping):

--- a/src/hades/config/check.py
+++ b/src/hades/config/check.py
@@ -1,8 +1,8 @@
-import os
-import socket
-import grp
-import pwd
 import collections
+import grp
+import os
+import pwd
+import socket
 
 import netaddr
 from pyroute2.iproute import IPRoute

--- a/src/hades/config/export.py
+++ b/src/hades/config/export.py
@@ -1,11 +1,13 @@
-import logging
-import re
 import collections
+import logging
+import os
+import re
+import sys
 
 import netaddr
 
-from hades.config.loader import get_config
-
+from hades.common.cli import ArgumentParser, parser as parent_parser
+from hades.config.loader import load_config
 
 logger = logging.getLogger('hades.config.export')
 shell_types = (int, str, bool, netaddr.IPAddress, netaddr.IPNetwork)
@@ -22,7 +24,11 @@ def escape(value):
 
 
 def main():
-    config = get_config()
+    parser = ArgumentParser(description='Export options as shell '
+                                                 'variables',
+                            parents=[parent_parser])
+    args = parser.parse_args()
+    config = load_config(args.config)
     for name, value in config.items():
         escaped_name = escape(str(name))
         if isinstance(value, shell_types):
@@ -44,4 +50,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/src/hades/config/export.py
+++ b/src/hades/config/export.py
@@ -24,6 +24,35 @@ def escape(value):
     return pattern.sub(replacement, str(value))
 
 
+def export(config, output_format, file):
+    """
+    Export config as shell variables.
+    :param config: Configuration to export
+    :param output_format: One of systemd, posix, bash, zsh
+    :param file: File-like object
+    """
+    mappings = output_format in ('bash', 'ksh', 'zsh')
+    sequences = output_format in ('bash', 'ksh', 'zsh')
+    for name, value in config.items():
+        name = escape(name)
+        if isinstance(value, shell_types):
+            print("{}={}".format(name, escape(value)), file=file)
+        elif isinstance(value, collections.Mapping) and mappings:
+            if output_format == 'bash':
+                print("declare -A {}".format(name), file=file)
+            if output_format in ('ksh', 'zsh'):
+                print("typeset -A {}".format(name), file=file)
+            value = ' '.join("[{}]={}".format(escape(k), escape(v))
+                             for k, v in value.items()
+                             if isinstance(k, shell_types) and
+                             isinstance(v, shell_types))
+            print("{}=({})".format(name, value), file=file)
+        elif isinstance(value, collections.Sequence) and sequences:
+            value = ' '.join(escape(v) for v in value
+                             if isinstance(v, shell_types))
+            print("{}=({})".format(name, value), file=file)
+
+
 def main():
     parser = ArgumentParser(description='Export options as shell '
                                                  'variables',
@@ -39,26 +68,7 @@ def main():
                         help='Output destination (default: stdout)')
     args = parser.parse_args()
     config = load_config(args.config)
-    mappings = args.format in ('bash', 'ksh', 'zsh')
-    sequences = args.format in ('bash', 'ksh', 'zsh')
-    for name, value in config.items():
-        name = escape(name)
-        if isinstance(value, shell_types):
-            print("{}={}".format(name, escape(value)), file=args.file)
-        elif isinstance(value, collections.Mapping) and mappings:
-            if args.format == 'bash':
-                print("declare -A {}".format(name), file=args.file)
-            if args.format in ('ksh', 'zsh'):
-                print("typeset -A {}".format(name), file=args.file)
-            value = ' '.join("[{}]={}".format(escape(k), escape(v))
-                             for k, v in value.items()
-                             if isinstance(k, shell_types) and
-                             isinstance(v, shell_types))
-            print("{}=({})".format(name, value), file=args.file)
-        elif isinstance(value, collections.Sequence) and sequences:
-            value = ' '.join(escape(v) for v in value
-                             if isinstance(v, shell_types))
-            print("{}=({})".format(name, value), file=args.file)
+    export(config, args.format, args.file)
     return os.EX_OK
 
 

--- a/src/hades/config/export.py
+++ b/src/hades/config/export.py
@@ -1,3 +1,4 @@
+import argparse
 import collections
 import logging
 import os
@@ -26,25 +27,39 @@ def escape(value):
 def main():
     parser = ArgumentParser(description='Export options as shell '
                                                  'variables',
+                            epilog='Python sequence and mapping types will '
+                                   'only be exported, if the destination '
+                                   'format support it',
                             parents=[parent_parser])
+    parser.add_argument('--format', choices=('systemd', 'posix', 'bash', 'ksh',
+                                             'zsh'),
+                        default='systemd', help='Export format.')
+    parser.add_argument('file', type=argparse.FileType('wb'), metavar='FILE',
+                        default='-', nargs='?',
+                        help='Output destination (default: stdout)')
     args = parser.parse_args()
     config = load_config(args.config)
+    mappings = args.format in ('bash', 'ksh', 'zsh')
+    sequences = args.format in ('bash', 'ksh', 'zsh')
     for name, value in config.items():
-        escaped_name = escape(str(name))
+        name = escape(name)
         if isinstance(value, shell_types):
-            print("{}={}".format(escaped_name, escape(value)))
-        elif isinstance(value, collections.Mapping):
-            print("declare -A {}".format(name))
-            for k, v in value.items():
-                if isinstance(v, shell_types):
-                    print("{}[{}]={}".format(escaped_name, escape(str(k)),
-                                             escape(str(v))))
-        elif isinstance(value, collections.Sequence):
-            print("declare -a {}".format(name))
-            for index, v in enumerate(value):
-                if isinstance(v, shell_types):
-                    print("{}[{}]={}".format(escaped_name, index,
-                                             escape(str(v))))
+            print("{}={}".format(name, escape(value)), file=args.file)
+        elif isinstance(value, collections.Mapping) and mappings:
+            if args.format == 'bash':
+                print("declare -A {}".format(name), file=args.file)
+            if args.format in ('ksh', 'zsh'):
+                print("typeset -A {}".format(name), file=args.file)
+            value = ' '.join("[{}]={}".format(escape(k), escape(v))
+                             for k, v in value.items()
+                             if isinstance(k, shell_types) and
+                             isinstance(v, shell_types))
+            print("{}=({})".format(name, value), file=args.file)
+        elif isinstance(value, collections.Sequence) and sequences:
+            value = ' '.join(escape(v) for v in value
+                             if isinstance(v, shell_types))
+            print("{}=({})".format(name, value), file=args.file)
+    return os.EX_OK
 
 
 if __name__ == '__main__':

--- a/src/hades/config/export.py
+++ b/src/hades/config/export.py
@@ -32,21 +32,19 @@ def main():
     for name, value in config.items():
         escaped_name = escape(str(name))
         if isinstance(value, shell_types):
-            print("export {}={}".format(escaped_name, escape(value)))
+            print("{}={}".format(escaped_name, escape(value)))
         elif isinstance(value, collections.Mapping):
             print("declare -A {}".format(name))
             for k, v in value.items():
                 if isinstance(v, shell_types):
                     print("{}[{}]={}".format(escaped_name, escape(str(k)),
                                              escape(str(v))))
-            print("export {}".format(escaped_name))
         elif isinstance(value, collections.Sequence):
             print("declare -a {}".format(name))
             for index, v in enumerate(value):
                 if isinstance(v, shell_types):
                     print("{}[{}]={}".format(escaped_name, index,
                                              escape(str(v))))
-            print("export {}".format(escaped_name))
 
 
 if __name__ == '__main__':

--- a/src/hades/config/loader.py
+++ b/src/hades/config/loader.py
@@ -93,8 +93,9 @@ class CheckWrapper(collections.Mapping):
 
 
 def get_defaults():
-    return {name: option.default for name, option in OptionMeta.options.items()
-            if option.default is not None}
+    return ConfigObject((name, option.default)
+                        for name, option in OptionMeta.options.items()
+                        if option.default is not None)
 
 
 def check_config(config, runtime_checks=False):

--- a/src/hades/config/loader.py
+++ b/src/hades/config/loader.py
@@ -13,35 +13,40 @@ def from_object(obj):
     return {name: getattr(obj, name) for name in dir(obj) if name.isupper()}
 
 
-class ConfigObject(collections.Mapping):
+class ConfigObject(collections.MutableMapping):
     """
     An object suitable to be loaded by Flask or Celery.
     """
     def __init__(self, d):
-        self._data = d
-        for name, value in d.items():
-            setattr(self, name, value)
+        super().__init__()
+        self.__dict__.update(d)
 
     def __iter__(self):
-        return iter(self._data)
+        return iter(self.__dict__)
 
     def __len__(self):
-        return len(self._data)
+        return len(self.__dict__)
 
     def __contains__(self, x):
-        return x in self._data
+        return x in self.__dict__
 
     def __getitem__(self, item):
-        return self._data[item]
+        return self.__dict__[item]
+
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
+
+    def __delitem__(self, key):
+        del self.__dict__[key]
 
     def keys(self):
-        return self._data.keys()
+        return self.__dict__.keys()
 
     def values(self):
-        return self._data.values()
+        return self.__dict__.values()
 
     def items(self):
-        return self._data.items()
+        return self.__dict__.items()
 
 
 class CheckWrapper(collections.Mapping):

--- a/src/hades/config/options.py
+++ b/src/hades/config/options.py
@@ -1,7 +1,7 @@
-from datetime import timedelta
+import collections
 import random
 import string
-import collections
+from datetime import timedelta
 
 import netaddr
 

--- a/src/hades/config/options.py
+++ b/src/hades/config/options.py
@@ -442,13 +442,6 @@ class HADES_AUTH_DNSMASQ_LEASE_FILE(Option):
     runtime_check = check.file_creatable
 
 
-class HADES_AUTH_DNSMASQ_SIGNAL_SOCKET(Option):
-    """Path to the Unix socket of the SignalProxyDaemon"""
-    default = '/run/hades/agent/auth-dnsmasq.sock'
-    type = str
-    runtime_check = check.file_creatable
-
-
 class HADES_AUTH_DHCP_DOMAIN(Option):
     """DNS domain of authenticated users"""
     default = 'users.agdsn.de'

--- a/src/hades/config/options.py
+++ b/src/hades/config/options.py
@@ -27,13 +27,18 @@ class Option(object, metaclass=OptionMeta):
     static_check = None
 
 
-def equal_to(other):
-    if isinstance(other, type) and issubclass(other, Option):
-        other_name = other.__name__
-    elif isinstance(other, str):
-        other_name = other
+def coerce(value):
+    if isinstance(value, type) and issubclass(value, Option):
+        return value.__name__
     else:
-        raise TypeError("Expected Option subclass or str")
+        return value
+
+
+def equal_to(other):
+    other_name = coerce(other)
+    if not isinstance(other_name, str):
+        raise TypeError("Expected Option subclass or str, was {}"
+                        .format(type(other_name)))
 
     def f(config, name):
         try:
@@ -58,6 +63,9 @@ def deferred_format(fmt_string, *args, **kwargs):
     :param kwargs:
     :return:
     """
+    args = tuple(coerce(arg) for arg in args)
+    kwargs = {k: coerce(v) for k, v in kwargs}
+
     def f(config, name):
         try:
             fmt_args = tuple(config[a] for a in args)
@@ -877,7 +885,7 @@ class CELERY_TIMEZONE(Option):
 
 
 class CELERY_DEFAULT_QUEUE(Option):
-    default = deferred_format("hades-site-{}", 'HADES_SITE_NAME')
+    default = deferred_format("hades-site-{}", HADES_SITE_NAME)
     type = str
 
 

--- a/src/hades/dnsmasq/util.py
+++ b/src/hades/dnsmasq/util.py
@@ -5,13 +5,13 @@ import signal
 import netaddr
 
 from hades.common.db import get_all_dhcp_hosts
-from hades.config.loader import CheckWrapper, get_config
+from hades.config.loader import get_config
 
 logger = logging.getLogger(__name__)
-config = CheckWrapper(get_config())
 
 
 def reload_auth_dnsmasq():
+    config = get_config(runtime_checks=True)
     pid_file = config['HADES_AUTH_DNSMASQ_PID_FILE']
     try:
         with open(pid_file) as f:
@@ -46,6 +46,7 @@ def generate_dhcp_host_reservations(hosts):
 
 
 def generate_dhcp_hosts_file():
+    config = get_config(runtime_checks=True)
     logger.info("Generating DHCP hosts file")
     hosts = get_all_dhcp_hosts()
     file_name = config['HADES_AUTH_DNSMASQ_HOSTS_FILE']


### PR DESCRIPTION
* Some obsolete options are removed.
* The configuration has to loaded explicitly with `load_config` and can later be obtained using `get_config`, no global `config` objects that are loaded at import time are present.
* Shell config variables are no longer declared exportable
* The config objects uses its __dict__ as underlying storage instead of a separate dictionary
* Some other fixes