### PR TITLE
Adds Compatibility for D-Link DGS-3100-24 in domitory Gerokstraße 38

### DIFF
--- a/templates/freeradius/policy.d/mac_auth.j2
+++ b/templates/freeradius/policy.d/mac_auth.j2
@@ -30,7 +30,7 @@ set_cleartext_password {
 }
 
 verify_calling_station_id {
-	if ((&Service-Type == Call-Check) && &User-Name =~ /^${policy.mac-addr-regexp}$/i) {
+	if ((&Service-Type) && (&Service-Type == Call-Check) && &User-Name =~ /^${policy.mac-addr-regexp}$/i) {
 		# Check that the Calling-Station-Id reported by the NAS equals the
 		# User-Name to ensure that the request originated from the correct
 		# device, otherwise a user could enter the MAC address if Web-Auth is

--- a/templates/freeradius/sites-available/hades.j2
+++ b/templates/freeradius/sites-available/hades.j2
@@ -54,10 +54,6 @@ server hades {
 		preprocess
 
 		chap
-		eap {
-			ok = return
-			updated = return
-		}
 		{% if HADES_RADIUS_DATABASE_FAIL_ACCEPT %}
 		redundant {
 			lookup_sql
@@ -66,6 +62,12 @@ server hades {
 		{% else %}
 		lookup_sql
 		{% endif %}
+
+		eap {
+			ok = return
+			updated = return
+		}
+
 		pap
 	}
 


### PR DESCRIPTION
The DGS-3100-24-Switches in the dormitory Gerokstraße 38 don't send a Service-Type in their request so the current implementation of verify_calling_station_id fails, as is assumes that this attribute is present.

Also these switches use eap and on eap we return before querying the database and thereby do not receive the required attributes for setting a vlan. The D-Links radius implementation sets the port to unauthenticated, if the authenticated message form radius does not contain a vlan-attribute. So the client is blocked and has no chance to see the captive portal or use the internet.

I testet the changes in our live-setup and could correctly authenticate a client with it.