### PR TITLE
Allow authentication for unknown MAC addresses

### DIFF
--- a/templates/freeradius/mods-config/sql/main/postgresql/queries.conf
+++ b/templates/freeradius/mods-config/sql/main/postgresql/queries.conf
@@ -117,7 +117,7 @@ client_query = "\
 authorize_check_query = "\
 	SELECT \"Priority\", \"UserName\", \"Attribute\", \"Value\", \"Op\" \
 	FROM ${authcheck_table} \
-	WHERE \"UserName\" = '%{SQL-User-Name}' \
+	WHERE (\"UserName\" = '%{SQL-User-Name}') IS NOT FALSE \
 	AND ((\"NASIPAddress\" = '%{NAS-IP-Address}') IS NOT FALSE) \
 	AND ((\"NASPortId\" = '%{%{NAS-Port-ID}:-%{NAS-Port}}') IS NOT FALSE) \
 	ORDER BY \"Priority\", \"NASIPAddress\" NULLS LAST, \"NASPortId\" NULLS LAST"
@@ -125,7 +125,7 @@ authorize_check_query = "\
 authorize_reply_query = "\
 	SELECT \"Priority\", \"UserName\", \"Attribute\", \"Value\", \"Op\" \
 	FROM ${authreply_table} \
-	WHERE \"UserName\" = '%{SQL-User-Name}' \
+	WHERE (\"UserName\" = '%{SQL-User-Name}') IS NOT FALSE \
 	AND ((\"NASIPAddress\" = '%{NAS-IP-Address}') IS NOT FALSE) \
 	AND ((\"NASPortId\" = '%{%{NAS-Port-ID}:-%{NAS-Port}}') IS NOT FALSE) \
 	ORDER BY \"Priority\", \"NASIPAddress\" NULLS LAST, \"NASPortId\" NULLS LAST"
@@ -205,7 +205,7 @@ authorize_group_reply_query = "\
 group_membership_query = "\
 	SELECT \"GroupName\" \
 	FROM ${usergroup_table} \
-	WHERE \"UserName\"='%{SQL-User-Name}' \
+	WHERE (\"UserName\"='%{SQL-User-Name}') IS NOT FALSE \
 	AND ((\"NASIPAddress\" = '%{NAS-IP-Address}') IS NOT FALSE) \
 	AND ((\"NASPortId\" = '%{%{NAS-Port-ID}:-%{NAS-Port}}') IS NOT FALSE) \
 	ORDER BY \"Priority\", \"NASIPAddress\" NULLS LAST, \"NASPortId\" NULLS LAST"

--- a/templates/schema.sql.j2
+++ b/templates/schema.sql.j2
@@ -325,7 +325,7 @@ ALTER FOREIGN TABLE foreign_nas OWNER TO "{{ constants.DATABASE_USER }}";
 
 CREATE FOREIGN TABLE foreign_radcheck (
     "Priority" integer /* NOT NULL */,
-    "UserName" text  /* NOT NULL */,
+    "UserName" text,
     {% if HADES_POSTGRESQL_FOREIGN_TABLE_RADCHECK_NASIPADDRESS_STRING %}
     "NASIPAddress" text,
     {% else %}
@@ -388,7 +388,7 @@ ALTER FOREIGN TABLE foreign_radgroupreply OWNER TO "{{ constants.DATABASE_USER }
 
 CREATE FOREIGN TABLE foreign_radreply (
     "Priority" integer /* NOT NULL */,
-    "UserName" text /* NOT NULL */,
+    "UserName" text,
     {% if HADES_POSTGRESQL_FOREIGN_TABLE_RADREPLY_NASIPADDRESS_STRING %}
     "NASIPAddress" text,
     {% else %}
@@ -412,7 +412,7 @@ ALTER FOREIGN TABLE foreign_radreply OWNER TO "{{ constants.DATABASE_USER }}";
 --
 
 CREATE FOREIGN TABLE foreign_radusergroup (
-    "UserName" text /* NOT NULL */,
+    "UserName" text,
     {% if HADES_POSTGRESQL_FOREIGN_TABLE_RADUSERGROUP_NASIPADDRESS_STRING %}
     "NASIPAddress" text,
     {% else %}
@@ -542,8 +542,7 @@ CREATE MATERIALIZED VIEW radcheck AS
     foreign_radcheck."Op",
     foreign_radcheck."Value"
    FROM foreign_radcheck
-  WHERE ((foreign_radcheck."UserName" IS NOT NULL)
-    AND (foreign_radcheck."Attribute" IS NOT NULL)
+  WHERE ((foreign_radcheck."Attribute" IS NOT NULL)
     AND (foreign_radcheck."Op" IS NOT NULL)
     AND (foreign_radcheck."Value" IS NOT NULL))
   WINDOW w AS (PARTITION BY foreign_radcheck."UserName", foreign_radcheck."NASIPAddress", foreign_radcheck."NASPortId" ORDER BY foreign_radcheck."Priority")
@@ -600,7 +599,7 @@ ALTER TABLE radgroupreply OWNER TO "{{ constants.DATABASE_USER }}";
 
 CREATE TABLE radpostauth (
     "Id" bigint NOT NULL,
-    "UserName" text NOT NULL,
+    "UserName" text,
     "NASIPAddress" inet NOT NULL,
     "NASPortId" text,
     "PacketType" text NOT NULL,
@@ -652,8 +651,7 @@ CREATE MATERIALIZED VIEW radreply AS
     foreign_radreply."Op",
     foreign_radreply."Value"
    FROM foreign_radreply
-  WHERE ((foreign_radreply."UserName" IS NOT NULL)
-   AND (foreign_radreply."Attribute" IS NOT NULL)
+  WHERE ((foreign_radreply."Attribute" IS NOT NULL)
    AND (foreign_radreply."Op" IS NOT NULL)
    AND (foreign_radreply."Value" IS NOT NULL))
   WINDOW w AS (PARTITION BY foreign_radreply."UserName", foreign_radreply."NASIPAddress", foreign_radreply."NASPortId" ORDER BY foreign_radreply."Priority")
@@ -677,8 +675,7 @@ CREATE MATERIALIZED VIEW radusergroup AS
     foreign_radusergroup."GroupName",
     row_number() OVER w AS "Priority"
    FROM foreign_radusergroup
-  WHERE ((foreign_radusergroup."UserName" IS NOT NULL)
-   AND (foreign_radusergroup."GroupName" IS NOT NULL))
+  WHERE ((foreign_radusergroup."GroupName" IS NOT NULL))
   WINDOW w AS (PARTITION BY foreign_radusergroup."UserName", foreign_radusergroup."NASIPAddress", foreign_radusergroup."NASPortId" ORDER BY foreign_radusergroup."Priority")
   WITH DATA;
 

--- a/templates/schema_fdw.sql.j2
+++ b/templates/schema_fdw.sql.j2
@@ -91,7 +91,7 @@ ALTER TABLE nas OWNER TO "{{ constants.DATABASE_USER }}";
 
 CREATE TABLE radcheck (
     "Priority" integer NOT NULL,
-    "UserName" text NOT NULL,
+    "UserName" text,
     {% if HADES_POSTGRESQL_FOREIGN_TABLE_RADCHECK_NASIPADDRESS_STRING %}
     "NASIPAddress" text,
     {% else %}
@@ -142,7 +142,7 @@ ALTER TABLE radgroupreply OWNER TO "{{ constants.DATABASE_USER }}";
 
 CREATE TABLE radreply (
     "Priority" integer NOT NULL,
-    "UserName" text NOT NULL,
+    "UserName" text,
     {% if HADES_POSTGRESQL_FOREIGN_TABLE_RADREPLY_NASIPADDRESS_STRING %}
     "NASIPAddress" text,
     {% else %}
@@ -162,7 +162,7 @@ ALTER TABLE radreply OWNER TO "{{ constants.DATABASE_USER }}";
 --
 
 CREATE TABLE radusergroup (
-    "UserName" text NOT NULL,
+    "UserName" text,
     {% if HADES_POSTGRESQL_FOREIGN_TABLE_RADUSERGROUP_NASIPADDRESS_STRING %}
     "NASIPAddress" text,
     {% else %}


### PR DESCRIPTION
This patch will allow NULL entries for UserName in radcheck, radreply, and radusergroup and change the RADIUS queries so that any MAC address is matched if there is an entry with UserName being NULL.

- [x] Change RADIUS queries
- [x] Change database definitions
- [x] Add tests