### PR TITLE
Improve GNU make based configure “script”

### DIFF
--- a/configure.mk
+++ b/configure.mk
@@ -36,10 +36,13 @@ endef
 # Set VARIABLE to the output of executing CODE in a shell and add VARIABLE to
 # the list of substitution variables.
 define add_shell_substitution
-$(call add_substitution,
-    $1,
-    $(shell $(strip $2))
-    $(if $(filter-out 0,$(.SHELLSTATUS)),$(error Failed to execute $(strip $2)))
+$(if $(findstring undefined,$(origin $(strip $1))),
+    $(call add_substitution,
+        $1,
+        $(shell $(strip $2))
+        $(if $(filter-out 0,$(.SHELLSTATUS)),$(error Failed to execute $(strip $2)))
+    ),
+    $(eval SUBSTITUTIONS += $(strip $1))
 )
 endef
 
@@ -68,15 +71,20 @@ endef
 # optionally.
 # The variable is added to list of substitution variables.
 define require_program
-$(call add_substitution,$1,
-    $(if $(and $(filter-out undefined,$(origin 3)),$3),
-        $(call find_program,$2,$3),
-        $(call find_program,$2)
+$(if
+    $(findstring undefined,$(origin $(strip $1))),
+    $(call add_substitution,$1,
+        $(if $(and $(filter-out undefined,$(origin 3)),$3),
+            $(call find_program,$2,$3),
+            $(call find_program,$2)
+        )
     )
-)
-$(if $($(strip $1)),
-    $(info Found $(strip $2) at $($(strip $1))),
-    $(error Could not find $(strip $2) in PATH=$(if $(and $(filter-out undefined,$(origin 3)),$3),$(strip $3),$(PATH)))
+    $(if $($(strip $1)),
+        $(info Found $(strip $2) at $($(strip $1))),
+        $(error Could not find $(strip $2) in PATH=$(if $(and $(filter-out undefined,$(origin 3)),$3),$(strip $3),$(PATH)))
+    ),
+    $(info Using user-defined $(strip $2) at $($(strip $1)))
+    $(eval SUBSTITUTIONS += $(strip $1))
 )
 endef
 

--- a/configure.mk
+++ b/configure.mk
@@ -10,6 +10,10 @@ SHELL := $(shell if output="$$(command -v bash)"; then echo "$${output}"; fi)
 ifeq ($(strip $(SHELL)),)
 $(error Could not find bash)
 endif
+# Check for .SHELLSTATUS support (GNU make 4.2+)
+ifneq ($(.SHELLSTATUS),0)
+$(error Your make does not support .SHELLSTATUS)
+endif
 .SHELLFLAGS := -euo pipefail -c
 
 # --------- #
@@ -32,9 +36,10 @@ endef
 # Set VARIABLE to the output of executing CODE in a shell and add VARIABLE to
 # the list of substitution variables.
 define add_shell_substitution
-$(call add_substitution,$1,$(shell if output="$$($(strip $2))"; then echo "$$output"; fi))
-$(if $($(strip $1)),,
-	$(error Failed to execute $(strip $2) (No output or non-zero exit status))
+$(call add_substitution,
+    $1,
+    $(shell $(strip $2))
+    $(if $(filter-out 0,$(.SHELLSTATUS)),$(error Failed to execute $(strip $2)))
 )
 endef
 

--- a/configure.mk
+++ b/configure.mk
@@ -6,7 +6,7 @@ NULL :=
 # Shell #
 # ----- #
 
-SHELL := $(shell if output="$$(command -v bash)"; then echo "$${output}"; fi)
+SHELL := $(shell command -v bash)
 ifeq ($(strip $(SHELL)),)
 $(error Could not find bash)
 endif
@@ -50,18 +50,7 @@ endef
 # ---------------------------
 # Find the full path of a program. A specific PATH may be specified optionally.
 define find_program
-$(shell
-    $(if $(and $(filter-out undefined,$(origin 2)),$2),paths=($(strip $2));,IFS=':';paths=($$PATH);IFS=;)
-    for path in "$${paths[@]}"; do
-        for exec in $(strip $1); do
-            if [[ -x "$${path}/$${exec}" ]]; then
-                printf "%s/%s" "$$path" "$$exec";
-            exit 0;
-            fi;
-        done;
-    done;
-    exit 127
-)
+$(firstword $(foreach name,$1,$(wildcard $(addsuffix /$(name),$(subst :, ,$(if $(and $(filter-out undefined,$(origin 2)),$2),$(strip $2),$(PATH)))))))
 endef
 
 # require_program(VARIABLE, NAMES, [PATH])


### PR DESCRIPTION
A collection of improvement to the GNU make based configure “script” `configure.mk`:

* Usage outside of the Debian package build environment:
  * Find Postgres programs without Debian PgCommon perl module
  * Don't try to find programs or invoke the shell, if a substitution variable has already been defined by the user (e.g. env var or CLI var).
* Correctness/Troubleshooting
  * Always check the exit status when using the shell function (GNU Make `.SHELLSTATUS`).
  * Don't expand undefined optional parameters
* Performance
  * Find programs directly with make (without shell)